### PR TITLE
Comply with rate limit

### DIFF
--- a/_deploy/main.go
+++ b/_deploy/main.go
@@ -44,7 +44,7 @@ func main() {
 	must(err)
 
 	// Connect to zendesk
-	transport := BasicAuthTransport{
+	transport := ZendeskAuthTransport{
 		Username: Config.ZendeskUser + "/token",
 		Password: Config.ZendeskToken,
 	}


### PR DESCRIPTION
**Changes proposed in this pull request**
- Comply with Zendesk's rate limit while deploying the pages

**Please check**
- [ ] This PR deploys without incourring in any rate limiting


We sadly don't have a test environment, so we can only test it locally or in prod, and only if we actually incour in some rate limiting (which is very random, it depends on other API integrations we got)