### PR TITLE
HC-961 RP2040 and Uno Wifi Rev2 for Chromebook

### DIFF
--- a/content/Arduino Cloud/Arduino Chrome App/Which-boards-can-be-used-with-the-Web-editor-on-Chromebook.md
+++ b/content/Arduino Cloud/Arduino Chrome App/Which-boards-can-be-used-with-the-Web-editor-on-Chromebook.md
@@ -2,29 +2,33 @@
 title: "Which boards can be used with the Web editor on Chromebook?"
 ---
 
-The boards that are compatible with the Arduino Web Editor depends on the operating system. For Chrome OS on Chromebook, you can currently use the following boards:
+For Chrome OS on Chromebook, you can use the following boards with the Web Editor:
 
-* [Arduino UNO](https://store.arduino.cc/usa/arduino-uno-rev3)
-* [Arduino Mega](https://store.arduino.cc/usa/mega-2560-r3)
-* [Arduino Mega ADK](https://store.arduino.cc/usa/arduino-mega-adk-rev3)
-* [Arduino Nano (ATMega328)](https://store.arduino.cc/usa/arduino-nano)
-* [Nano 33 IoT](https://store.arduino.cc/products/arduino-nano-33-iot)
-* [Arduino Micro](https://store.arduino.cc/usa/arduino-micro)
-* [Arduino Leonardo](https://store.arduino.cc/products/arduino-leonardo-with-headers)
-* [Arduino Zero](https://store.arduino.cc/usa/arduino-zero)
-* [Arduino MKR1000](https://store.arduino.cc/usa/arduino-mkr1000)
-* [Arduino MKR WIFI 1010](https://store.arduino.cc/usa/mkr-wifi-1010)
-* [Arduino MKR Zero](https://store.arduino.cc/usa/arduino-mkrzero)
-* [Arduino MKR Fox 1200](https://store.arduino.cc/arduino-mkr-fox-1200-1408)
-* [Arduino MKR WAN 1300](https://store.arduino.cc/arduino-mkr-wan-1300-lora-connectivity-1414)
-* [Arduino MKR GSM 1400](https://store.arduino.cc/arduino-mkr-gsm-1400-1415)
-* [Arduino MKR NB 1500](https://store.arduino.cc/arduino-mkr-nb-1500-1413)
+* [Arduino UNO Rev3](https://docs.arduino.cc/hardware/uno-rev3)
+* [Arduino Mega 2560 Rev3](https://docs.arduino.cc/hardware/mega-2560)
+* [Arduino Nano (ATmega328)](https://docs.arduino.cc/hardware/nano)
+* [Arduino Nano 33 IoT](https://docs.arduino.cc/hardware/nano-33-iot)
+* [Arduino Micro](https://docs.arduino.cc/hardware/micro)
+* [Arduino Leonardo](https://docs.arduino.cc/hardware/leonardo)
+* [Arduino Zero](https://docs.arduino.cc/hardware/zero)
+* [Arduino MKR 1000 WiFi](https://docs.arduino.cc/hardware/mkr-1000-wifi)
+* [Arduino MKR WiFi 1010](https://docs.arduino.cc/hardware/mkr-wifi-1010)
+* [Arduino MKR Zero](https://docs.arduino.cc/hardware/mkr-zero)
+* [Arduino MKR Fox 1200](https://docs.arduino.cc/hardware/mkr-fox-1200)
+* [Arduino MKR WAN 1300](https://docs.arduino.cc/hardware/mkr-wan-1300)
+* [Arduino MKR GSM 1400](https://docs.arduino.cc/hardware/mkr-gsm-1400)
+* [Arduino MKR NB 1500](https://docs.arduino.cc/hardware/mkr-nb-1500)
+
+Can be made compatible with additional configuration:
+
+* [Arduino UNO WiFi Rev2](https://docs.arduino.cc/hardware/uno-wifi-rev2). Setup instructions [here](https://docscontent-karlsoderbychromebookunowifire.gtsb.io/tutorials/uno-wifi-rev2/uno-wifi-r2-chromebook-installation).
+* [Arduino Nano RP2040 Connect](https://docs.arduino.cc/hardware/nano-rp2040-connect). Setup instructions [here](https://docs.arduino.cc/tutorials/nano-rp2040-connect/rp2040-chromebook-upload).
 
 Retired boards:
 
 * [Arduino 101](https://docs.arduino.cc/retired/boards/arduino-101-619)
 * [Arduino Esplora](https://docs.arduino.cc/retired/boards/arduino-esplora)
 * [Arduino Pro](https://docs.arduino.cc/retired/boards/arduino-pro)
-* [Arduino Pro Mini (ATMega328)](https://docs.arduino.cc/retired/boards/arduino-pro-mini)
+* [Arduino Pro Mini (ATmega328)](https://docs.arduino.cc/retired/boards/arduino-pro-mini)
 
 Third-party boards are not supported on Chrome OS.


### PR DESCRIPTION
**Changes proposed in this pull request**
Updated [Which boards can be used with the Web editor on Chromebook?](https://support.arduino.cc/hc/en-us/articles/360014779899-Which-boards-can-be-used-with-the-Web-editor-on-Chromebook-) with Uno WiFi Rev2 and RP2040.