### PR TITLE
HC-968 Update Portenta breakout DIP switches

### DIFF
--- a/content/Hardware/Portenta Family/DIP-switches-on-Portenta-Breakout-board.md
+++ b/content/Hardware/Portenta Family/DIP-switches-on-Portenta-Breakout-board.md
@@ -6,20 +6,29 @@ The Arduino Portenta Breakout board makes all high-density connectors individual
 
 ![The top side of the Portenta Breakout board, with the DIP switches highlighted.](img/DIP_breakout.png)
 
-## DIP switches on the Portenta H7
+<table>
+<tbody>
+  <tr>
+    <td rowspan="2"><b>BOOT_SEL</b></td>
+    <td>ON</td>
+    <td>Keeps the Portenta in Boot mode</td>
+  </tr>
+  <tr>
+    <td>OFF</td>
+    <td>Operation mode (default)</td>
+  </tr>
+  <tr>
+    <td rowspan="2"><b>BOOT</b></td>
+    <td>ON</td>
+    <td>Enables the embedded bootloader. Firmware can be uploaded via the USB port on the breakout board (DFU). USB-A to USB-A (non-crossover) cable required. The Portenta H7 has to be powered through the USB-C connector or VIN.</td>
+  </tr>
+  <tr>
+    <td>OFF</td>
+    <td>Normal boot (default)</td>
+  </tr>
+</tbody>
+</table>
 
-The different positions and modes for the Portenta H7 are explained below.
-
-**BOOT_SEL:**
-
-* ON: Keeps the Portenta in Boot mode.
-* OFF: Operation mode (default)
-
-**BOOT:**
-
-* ON: Enables the embedded bootloader. Firmware can be upload via the USB port on the breakout board (DFU). USB-A to USB-A (non-crossover) cable required. The Portenta H7 has to be powered through the USB-C connector or VIN.
-* OFF: Boots normally (default)
-
-Users must pay special attention to the DIP switches position to ensure the right boot mode is selected before powering the board. If the RESET button does not behave as expected, or you are unable to enter _Bootloader Mode_, you should verify the DIP switch configuration.
+Pay attention to the position of the DIP switches to ensure the right boot mode is selected before powering the board. If the RESET button does not behave as expected, or you are unable to enter _Bootloader Mode_, you should verify the DIP switch configuration.
 
 **For the standard operation mode both DIP switches must be set to OFF**. To do so, simply position the white switches next to "1" and "2" respectively (opposite the "ON" label printed on the switch connector itself).


### PR DESCRIPTION
**Changes proposed in this pull request**
- Removed unneeded heading
- Removed the line "The different positions and modes for the **Portenta H7** are explained below"
- Formatted the positions as table instead of list