### PR TITLE
Add the new Arduino Cloud Editor BETA app for Chromebooks to doc

### DIFF
--- a/content/Arduino Cloud/Arduino Chrome App/Use-Arduino-with-Chromebook.md
+++ b/content/Arduino Cloud/Arduino Chrome App/Use-Arduino-with-Chromebook.md
@@ -24,7 +24,7 @@ You can write and upload sketches on Chrome OS with the Web Editor in Arduino Cl
 
 5. Start writing a new sketch in the editor, or use a sketch from the _Examples_ sidebar.
 
-Learn more about the Web Editor:
+## Learn more about the Web Editor:
 
 * [Uploading a simple example](https://docs.arduino.cc/cloud/web-editor/tutorials/getting-started/getting-started-web-editor#uploading-a-simple-example)
 * [Web Editor in Arduino Docs](https://docs.arduino.cc/cloud/web-editor)

--- a/content/Arduino Cloud/Arduino Chrome App/Use-Arduino-with-Chromebook.md
+++ b/content/Arduino Cloud/Arduino Chrome App/Use-Arduino-with-Chromebook.md
@@ -24,7 +24,7 @@ You can write and upload sketches on Chrome OS with the Web Editor in Arduino Cl
 
 5. Start writing a new sketch in the editor, or use a sketch from the _Examples_ sidebar.
 
-## Learn more about the Web Editor:
+## Learn more about the Web Editor
 
 * [Uploading a simple example](https://docs.arduino.cc/cloud/web-editor/tutorials/getting-started/getting-started-web-editor#uploading-a-simple-example)
 * [Web Editor in Arduino Docs](https://docs.arduino.cc/cloud/web-editor)

--- a/content/Arduino Cloud/Arduino Chrome App/Use-Arduino-with-Chromebook.md
+++ b/content/Arduino Cloud/Arduino Chrome App/Use-Arduino-with-Chromebook.md
@@ -28,3 +28,5 @@ Learn more about the Web Editor:
 
 * [Uploading a simple example](https://docs.arduino.cc/cloud/web-editor/tutorials/getting-started/getting-started-web-editor#uploading-a-simple-example)
 * [Web Editor in Arduino Docs](https://docs.arduino.cc/cloud/web-editor)
+
+>Please note: You can also download a BETA version of Arduino Cloud Editor, a new application for Chromebook, which is available for free on the [Google Store](https://play.google.com/store/apps/details?id=cc.arduino.create_editor). Right now, this application has more limited features than the current ChromeApp. However, it uses the new Progressive Web Application development framework from ChromeOS, which will be the recommended platform going forward. Your feedback on this BETA version would be greatly appreciated, as it will help us improve the app and continue to support Chromebook users in the future.


### PR DESCRIPTION
**Changes proposed in this pull request**
- Adds a note informing the user about the BETA version of Arduino Cloud Editor (same note as in [How do I use Arduino Education kits with a ChromeBook?](https://www.arduino.cc/education/how-do-i-use-arduino-education-kits-with-a-chromebook)
- Updates sub header's style

**Internal key:** HC-1001