### PR TITLE
Delete Where-are-the-building-instructions-for-the-Science-kit-experi…

### DIFF
--- a/content/Education and Kits/Science Kit/Where-are-the-building-instructions-for-the-Science-kit-experiments.md
+++ b/content/Education and Kits/Science Kit/Where-are-the-building-instructions-for-the-Science-kit-experiments.md
@@ -1,5 +1,0 @@
----
-title: "Where are the building instructions for the Science kit experiments?"
----
-
-Each Arduino Science Kit includes exclusive access to online educational materials. Go to [the kit registration page](https://create.arduino.cc/science-kit/register-code) and enter your unique access code to get started. It is also possible to go to [arduino.cc/education](https://www.arduino.cc/education) and click on **register kit**.


### PR DESCRIPTION
…ments.md

**Changes proposed in this pull request**
Remove [Where are the building instructions for the Science kit experiments?](https://support.arduino.cc/hc/en-us/articles/4403156724242-Where-are-the-building-instructions-for-the-Science-kit-experiments-) since these questions are covered by more general articles.

**Internal key:** HC-1003