### PR TITLE
Delocalize Swedish-specific Process Explorer link

### DIFF
--- a/content/Software and Downloads/Upload/Find-and-stop-process-blocking-a-port.md
+++ b/content/Software and Downloads/Upload/Find-and-stop-process-blocking-a-port.md
@@ -11,7 +11,7 @@ Learn how to find and stop a process blocking a port for your system (Windows, m
 
 ### Get the Process Explorer tool
 
-Download and install the [Process Explorer tool](https://docs.microsoft.com/sv-se/sysinternals/downloads/process-explorer) from Microsoft.
+Download and install the [Process Explorer tool](https://docs.microsoft.com/sysinternals/downloads/process-explorer) from Microsoft.
 
 ### 1. Find the port 'Service' value
 


### PR DESCRIPTION
The use of the Swedish language code in the link to Microsoft's web page for the Process Explorer tool contained an unnecessary Swedish language code, which caused the content to be displayed in that language regardless of the locale settings of the reader's computer.

**Changes proposed in this pull request**

Remove the language identifier from the link to cause it to automatically redirect to the appropriate version of the page for each reader's locale:

https://docs.microsoft.com/sysinternals/downloads/process-explorer

**Please check**
- [ ] This pull request changes an article title
- [ ] This pull request removes an article
