### PR TITLE
Remove obsolete fragment identifier from Arduino IDE 2.x download link

### DIFF
--- a/content/Software and Downloads/IDE Settings/Error-Could-not-create-the-Java-Virtual-Machine-Windows.md
+++ b/content/Software and Downloads/IDE Settings/Error-Could-not-create-the-Java-Virtual-Machine-Windows.md
@@ -76,4 +76,4 @@ If the `_JAVA_OPTIONS` variable is not set, reinstalling Arduino IDE is likely t
 
 ## Use Arduino IDE 2.0
 
-Newer versions of Arduino IDE runs without Java, avoiding the problem altogether. [Get it here](https://www.arduino.cc/en/software#future-version-of-the-arduino-ide).
+Newer versions of Arduino IDE runs without Java, avoiding the problem altogether. [Get it here](https://www.arduino.cc/en/software).


### PR DESCRIPTION
During the pre-release development phase of the project, the download links for Arduino IDE 2.x were on a sub-section of the "Software" page. For this reason, the linked URL included the fragment identifier `#future-version-of-the-arduino-ide` so that the page would load scrolled down to the anchor at that section near the bottom of the page.

With the 2.0.0 release, the Arduino IDE 2.x project has graduated to a production development phase. For this reason, the download links have been moved to the top of the "Software" page and the `future-version-of-the-arduino-ide` anchor removed from the page.

The previous link with that fragment is still perfectly functional, but the fragment to a non-existent anchor serves no purpose and also somewhat misrepresents the project status to users who notice the URL that was loaded.

## Changes proposed in this pull request

Remove obsolete fragment identifier from Arduino IDE 2.x download link

## Please check

- [ ] This pull request changes an article title
- [ ] This pull request removes an article
