### PR TITLE
Add support form link to bug report section of "About Arduino Project Hub"

### DIFF
--- a/content/About Arduino/My Arduino Account/About-Arduino-Project-Hub.md
+++ b/content/About Arduino/My Arduino Account/About-Arduino-Project-Hub.md
@@ -59,4 +59,4 @@ If you find a mistake or error in a project on Arduino Project Hub, please conta
 
 ### How can I report a technical issues with the platform?
 
-If the issue is related to the migration to the new platform, you can also contact the Arduino Project Hub support team for assistance.
+If the issue is related to the migration to the new platform, you can also contact the Arduino Project Hub support team for assistance via [this form](https://www.arduino.cc/en/contact-us/).


### PR DESCRIPTION
The section of the article on reporting bugs with the Project Hub platform instructs the user to contact support. Previously it did not provide any path for the user to follow to make that contact.

**Changes proposed in this pull request**

Add a link to the support contact form.

**Please check**
- [ ] This pull request changes an article title
- [ ] This pull request removes an article
