### PR TITLE
Clarify supported boards and recommended use of the new app for Chromebook [HC-1347]

### DIFF
--- a/content/Arduino Cloud/Arduino Chrome App/Use-Arduino-with-Chromebook.md
+++ b/content/Arduino Cloud/Arduino Chrome App/Use-Arduino-with-Chromebook.md
@@ -42,7 +42,7 @@ Follow these steps to install **Arduino Create for Education**:
 3. Click _Add app_ to confirm.
 4. Click _Launch app_ to start the Web Editor or go to [create.arduino.cc/editor](https://create.arduino.cc/editor).
 
-<a class="link-chevron-right" href="https://support.arduino.cc/hc/en-us/articles/4401881299090-Review-change-or-cancel-your-Arduino-Cloud-plan">Learn more about boards compatible with the Web Editor</a>
+<a class="link-chevron-right" href="https://support.arduino.cc/hc/en-us/articles/360014779899-Boards-compatible-with-the-Web-Editor">Learn more about boards compatible with the Web Editor</a>
 
 ---
 

--- a/content/Arduino Cloud/Arduino Chrome App/Use-Arduino-with-Chromebook.md
+++ b/content/Arduino Cloud/Arduino Chrome App/Use-Arduino-with-Chromebook.md
@@ -7,15 +7,11 @@ You can write and upload sketches on Chrome OS with the Web Editor in Arduino Cl
 
 ---
 
-## Install the Chromebook app
+## Install Arduino Cloud for Chromebook
 
-To use Arduino boards on Chromebook, you need to install an app from Arduino which handles serial communication with the board.
+To use Arduino boards on Chromebook, you need to install the **Arduino Cloud for Chromebook** app. This app handles serial communication with the board, and is replacing the previous Chrome Apps[^chrome-apps].
 
-### Arduino Cloud for Chromebook
-
-The **Arduino Cloud for Chromebook** app is recommended for most popular and newer boards.
-
-Follow these steps to install **Arduino Cloud for Chromebook**:
+Follow these steps to install Arduino Cloud for Chromebook:
 
 1. Open <a class="link-up-right" href="https://play.google.com/store/apps/details?id=cc.arduino.create_editor">Arduino Cloud for Chromebook (Google Play)</a>
 2. Click the **Install** button on the page.
@@ -33,16 +29,9 @@ The currently supported boards include:
 * Arduino RP2040 Connect
 * Arduino UNO WiFi Rev2
 
-### Arduino Create for Education
-
-Follow these steps to install **Arduino Create for Education**:
-
-1. Open <a class="link-up-right" href="https://chrome.google.com/webstore/detail/elmgohdonjdampbcgefphnlchgocpaij">Arduino Create for Education (Chrome web store)</a>
-2. Click _Add to Chrome_.
-3. Click _Add app_ to confirm.
-4. Click _Launch app_ to start the Web Editor or go to [create.arduino.cc/editor](https://create.arduino.cc/editor).
-
 <a class="link-chevron-right" href="https://support.arduino.cc/hc/en-us/articles/360014779899-Boards-compatible-with-the-Web-Editor">Learn more about boards compatible with the Web Editor</a>
+
+[^chrome-apps]: Chrome Apps are being [deprecated](https://blog.chromium.org/2020/08/changes-to-chrome-app-support-timeline.html), but are currently still available in the Chrome web store: see <a class="link-up-right" href="https://chrome.google.com/webstore/detail/arduino-create/dcgicpihgkmccjigalccipmjlnjopdfe">Arduino Create</a> and <a class="link-up-right" href="https://chrome.google.com/webstore/detail/elmgohdonjdampbcgefphnlchgocpaij">Arduino Create for Education</a>.
 
 ---
 

--- a/content/Arduino Cloud/Web Editor/Boards-compatible-with-the-Web-Editor.md
+++ b/content/Arduino Cloud/Web Editor/Boards-compatible-with-the-Web-Editor.md
@@ -14,40 +14,19 @@ Find boards that can be used with the Web Editor on your system:
 
 ## Web Editor on Chromebook
 
-Boards supported on the Web Editor with the [Arduino Cloud for Chromebook app](https://play.google.com/store/apps/details?id=cc.arduino.create_editor) (recommended):
+To use the Web Editor on Chromebook, you need to install the <a class="link-up-right" href="https://play.google.com/store/apps/details?id=cc.arduino.create_editor">Arduino Cloud for Chromebook</a> app.
+
+These boards are supported:
 
 * Arduino UNO R4 Minima
 * Arduino UNO R4 WiFi
 * Arduino UNO (R3 and older revisions)
 * Arduino MKR WiFi 1010
 * Arduino Nano 33 IoT
-* Arduino RP2040 Connect
-* Arduino UNO WiFi Rev2
+* Arduino Nano RP2040 Connect ([setup instructions](https://docs.arduino.cc/tutorials/nano-rp2040-connect/rp2040-chromebook-upload))
+* Arduino UNO WiFi Rev2 ([setup instructions](https://docscontent-karlsoderbychromebookunowifire.gtsb.io/tutorials/uno-wifi-rev2/uno-wifi-r2-chromebook-installation))
 
-Boards supported on the Web Editor with [Arduino Create for Education Chrome app](https://chrome.google.com/webstore/detail/arduino-create-for-educat/elmgohdonjdampbcgefphnlchgocpaij) (legacy):
-
-<!-- * [Arduino 101](https://docs.arduino.cc/retired/boards/arduino-101-619) -->
-* Arduino Esplora
-* Arduino Leonardo
-* Arduino Mega 2560 Rev3
-* Arduino Micro
-* Arduino MKR 1000 WiFi
-* Arduino MKR Fox 1200
-* Arduino MKR GSM 1400
-* Arduino MKR NB 1500
-* Arduino MKR WAN 1300
-* Arduino MKR WiFi 1010
-* Arduino MKR Zero
-* Arduino Nano (ATmega328)
-* Arduino Nano 33 IoT
-* Arduino Nano RP2040 Connect ([additional setup required](https://docs.arduino.cc/tutorials/nano-rp2040-connect/rp2040-chromebook-upload))
-* Arduino Pro
-* Arduino Pro Mini (ATmega328)
-* Arduino UNO (R3 and older revisions
-* Arduino UNO WiFi Rev2 ([additional setup required](https://docscontent-karlsoderbychromebookunowifire.gtsb.io/tutorials/uno-wifi-rev2/uno-wifi-r2-chromebook-installation))
-* Arduino Zero
-
-Third-party boards are not supported on Chrome OS.
+<a class="link-chevron-right" href="https://support.arduino.cc/hc/en-us/articles/360016495639-Use-Arduino-with-Chromebook">Learn more about using Arduino with Chromebook</a>
 
 ---
 
@@ -55,7 +34,9 @@ Third-party boards are not supported on Chrome OS.
 
 ## Web Editor on Windows, macOS, and Linux
 
-The Web Editor on Windows, macOS, and Linux can be used with these boards:
+To use the Web Editor on Windows, macOS, and Linux, you need to install the <a class="link-up-right" href="https://create.arduino.cc/getting-started/plugin">Arduino Create Agent</a>.
+
+These boards are supported:
 
 * Arduino Due
 * Arduino Duemilanove or Diecimila
@@ -89,6 +70,7 @@ The Web Editor on Windows, macOS, and Linux can be used with these boards:
 * Arduino Nicla Sense ME
 * Arduino Nicla Vision
 * Arduino Nicla Voice
+* Arduino Portenta C33
 * Arduino Portenta H7
 * Arduino Portenta X8
 * Arduino Primo

--- a/content/Arduino Cloud/Web Editor/The-Arduino-board-shows-a-red-cross.md
+++ b/content/Arduino Cloud/Web Editor/The-Arduino-board-shows-a-red-cross.md
@@ -9,8 +9,4 @@ If you are trying to connect your Arduino board to the Arduino Web Editor and yo
 
 First of all, please check that the board chosen corresponds with the one connected and the port selected.
 
-If you are using a Chromebook, please note that you will need to have the Arduino Chrome App installed.
-
-* If you purchased the Arduino Create app from the Chrome Web Store as a single user this is the link to the app you must install: [Arduino Create Single User](https://chrome.google.com/webstore/detail/arduino-create/dcgicpihgkmccjigalccipmjlnjopdfe?hl=en).
-
-* If you are part of a school or organizations that owns an Arduino Chrome App plan for education you must obtain the app from this other link [Chrome App for Education](https://chrome.google.com/webstore/detail/arduino-create-for-educat/elmgohdonjdampbcgefphnlchgocpaij)
+If you are using a Chromebook, see please note that you will need to have the <a class="link-up-right" href="https://play.google.com/store/apps/details?id=cc.arduino.create_editor">Arduino Cloud for Chromebook app</a> installed.


### PR DESCRIPTION
Updates the following articles:

* https://support.arduino.cc/hc/en-us/articles/360016495639-Use-Arduino-with-Chromebook
* https://support.arduino.cc/hc/en-us/articles/360014779899-Boards-compatible-with-the-Web-Editor