### PR TITLE
Document UNO R4 WiFi-specific fix for "`No device found on ...`" upload error

### DIFF
--- a/content/Software Support/Upload/Errors-when-uploading-a-sketch.md
+++ b/content/Software Support/Upload/Errors-when-uploading-a-sketch.md
@@ -102,6 +102,14 @@ No device found on <port>
 
 4. See [Find and stop process blocking a port](https://support.arduino.cc/hc/en-us/articles/4407830972050-Find-and-stop-process-blocking-a-port).
 
+#### If you are uploading to UNO R4 WiFi
+
+1. Press and release the button marked "**RESET**" on the board quickly twice. The LED marked "**L**" on the board should now be pulsing.
+
+2. Select the port of the board from the menu in Arduino IDE. The port might have changed after the previous step, so make sure to verify that it is selected.
+
+Now try uploading the sketch to your board again.
+
 <a id="no-board-on-selected-port"></a>
 
 ### Couldn't find a Board on the selected port


### PR DESCRIPTION
When an [**UNO R4 WiFi**](https://docs.arduino.cc/hardware/uno-r4-wifi) board is running a sketch that uses the HID capabilities, the port address changes during the upload. Since this change does not occur under other conditions, the platform is not configured to handle such a change. This causes uploads via the standard procedure to fail under these conditions (https://github.com/arduino/ArduinoCore-renesas/issues/73):

```text
No device found on <port>
```

This error can occur under other conditions and with other boards, so there is already an entry for it in the Help Center. However, the documented fixes are not applicable to the error as it occurs under these special conditions.

There is a reliable fix for the error specific to the UNO R4 WiFi, which was not previously documented in the article. The addition of that fix to the article is proposed by this pull request.

### Related

- https://github.com/arduino/ArduinoCore-renesas/pull/74#issuecomment-1665193136
- https://github.com/arduino/docs-content/pull/1246