### PR TITLE
Improve pin column names for "Nano family overview" [HC-1420]

### DIFF
--- a/content/Hardware Support/Nano Family/Nano-family-overview.md
+++ b/content/Hardware Support/Nano Family/Nano-family-overview.md
@@ -17,7 +17,7 @@ Despite the similarities, there are subtle differences in some Nano boards in or
 
 ## Pinout differences
 
-The table below presents an overview of the pinout differences:
+The table below presents an overview of the pinout differences visible on the board's silk:
 
 <table>
   <tr>

--- a/content/Hardware Support/Nano Family/Nano-family-overview.md
+++ b/content/Hardware Support/Nano Family/Nano-family-overview.md
@@ -22,9 +22,9 @@ The table below presents an overview of the pinout differences visible on the bo
 <table>
   <tr>
     <th>Board</th>
-    <th>Analog Header Reset</th>
-    <th>AREF</th>
-    <th>5V</th>
+    <th>"RST/REC/B1" pin</th>
+    <th>“AREF/ B0” pin</th>
+    <th>“5V/ VUSB/ VBUS” pin</th>
   </tr>
   <tr>
     <td>Nano</td>


### PR DESCRIPTION
- Updates the table description to mention that it shows an overview of the differences visible on the board's silk.
- Updates the table column names to limit the risk of confusion (for example we don’t want to imply that there will always be 5 V power on the VUSB pin)