### PR TITLE
Small update to ASEC-24-001, focusing on the library [HC-1494]

### DIFF
--- a/content/About Arduino/Arduino Security Bulletins/ASEC-24-001-Vulnerabilities-in-ArduinoModbus-Library.md
+++ b/content/About Arduino/Arduino Security Bulletins/ASEC-24-001-Vulnerabilities-in-ArduinoModbus-Library.md
@@ -13,7 +13,10 @@ Fixed Version: 1.0.9
 
 This security bulletin provides important information regarding a security update for the [ArduinoModbus](https://github.com/arduino-libraries/ArduinoModbus) library.
 
+The library can be included in user-developed firmware to perform Modbus communication on compatible products, such as Arduino Opta and Portenta Machine Control.
+
 During a security analysis, we identified that the component is impacted by the known vulnerabilities as it implements a vulnerable version of the [libmodbus](https://github.com/stephane/libmodbus) library.
+
 The indirectly inherited known vulnerabilities which affect the [ArduinoModbus](https://github.com/arduino-libraries/ArduinoModbus) component are:
 
 * [CVE-2022-0367](https://nvd.nist.gov/vuln/detail/CVE-2022-0367)

--- a/content/About Arduino/Arduino Security Bulletins/ASEC-24-001-Vulnerabilities-in-ArduinoModbus-Library.md
+++ b/content/About Arduino/Arduino Security Bulletins/ASEC-24-001-Vulnerabilities-in-ArduinoModbus-Library.md
@@ -5,15 +5,13 @@ id: 12736735312796
 
 Bulletin ID: ASEC-24-001  
 Date: Feb 13, 2024  
-Product / Component: ArduinoModbus library, Arduino Opta  
+Product / Component: ArduinoModbus library  
 Affected Versions: &lt;= 1.0.8  
 Fixed Version: 1.0.9
 
 ## Summary
 
 This security bulletin provides important information regarding a security update for the [ArduinoModbus](https://github.com/arduino-libraries/ArduinoModbus) library.
-
-It is important to say that this library is used in the Arduino Opta product when the user-developed firmware includes the aforementioned library to perform Modbus communication.
 
 During a security analysis, we identified that the component is impacted by the known vulnerabilities as it implements a vulnerable version of the [libmodbus](https://github.com/stephane/libmodbus) library.
 The indirectly inherited known vulnerabilities which affect the [ArduinoModbus](https://github.com/arduino-libraries/ArduinoModbus) component are:
@@ -22,6 +20,7 @@ The indirectly inherited known vulnerabilities which affect the [ArduinoModbus](
 * [CVE-2019-14463](https://nvd.nist.gov/vuln/detail/CVE-2019-14463)
 
 To address these vulnerabilities, we have released an updated library, which includes the required security fixes.
+
 Therefore, to maintain the security of your systems it is advised to update the [ArduinoModbus](https://github.com/arduino-libraries/ArduinoModbus) to the [1.0.9](https://github.com/arduino-libraries/ArduinoModbus/releases/tag/1.0.9) version as soon as possible.
 
 ## Impact
@@ -39,7 +38,6 @@ Update the component's library to [ArduinoModbus 1.0.9](https://github.com/ardui
 For further information visit the following links:
 
 * [https://www.arduino.cc/reference/en/libraries/arduinomodbus/](https://www.arduino.cc/reference/en/libraries/arduinomodbus/)
-* [https://www.arduino.cc/pro/hardware-arduino-opta](https://www.arduino.cc/pro/hardware-arduino-opta)
 * [https://nvd.nist.gov/vuln/detail/CVE-2019-14463](https://nvd.nist.gov/vuln/detail/CVE-2019-14463)
 * [https://nvd.nist.gov/vuln/detail/CVE-2022-0367](https://nvd.nist.gov/vuln/detail/CVE-2022-0367)
 * [https://github.com/arduino-libraries/ArduinoModbus/releases/tag/1.0.9](https://github.com/arduino-libraries/ArduinoModbus/releases/tag/1.0.9)

--- a/content/Arduino Cloud/Spaces/About-spaces-and-plan-usage.md
+++ b/content/Arduino Cloud/Spaces/About-spaces-and-plan-usage.md
@@ -3,7 +3,7 @@ title: About spaces and plan usage
 id: 12679143837340
 ---
 
-Learn how use Cloud plan features in Spaces in Arduino Cloud.
+Learn how to use Cloud plan features in Spaces in Arduino Cloud.
 
 In this article:
 


### PR DESCRIPTION
For ASEC-24-001, the vulnerable asset was the ArduinoModbus library.

The current version of the article mentions Opta specifically, but the library can be used with other hardware.

This PR removes specific mentions of Opta, putting the focus on the library itself.