### PR TITLE
Add missing article IDs

### DIFF
--- a/content/About Arduino/Trademarks & Licensing/Trademark-guide-for-compatible-products.md
+++ b/content/About Arduino/Trademarks & Licensing/Trademark-guide-for-compatible-products.md
@@ -1,5 +1,6 @@
 ---
 title: "Trademark guide for compatible products"
+id: 13369565907740
 ---
 
 This guide covers the basic trademark rules you must follow when developing products based on, or compatible with, Arduino. By following these guidelines, you will be able to develop, share, and even commercialize your products without violating Arduino’s Intellectual Property. Please note that Arduino’s general Intellectual Property terms and conditions can be found [here](https://www.arduino.cc/en/trademark).

--- a/content/About Arduino/Trademarks & Licensing/Trademark-guide-for-courses-workshops-and-tutorials.md
+++ b/content/About Arduino/Trademarks & Licensing/Trademark-guide-for-courses-workshops-and-tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: "Trademark guide for courses, workshops and tutorials"
+id: 13369290163740
 ---
 
 This guide covers the basic trademark rules you must follow when developing a course, workshop, or tutorial based on Arduino (Examples include but are not limited to: video tutorials, free or paid online courses, and in-person workshops). By following these guidelines, you will be able to develop, share, and even commercialize your content without violating Arduino’s Intellectual Property.

--- a/content/About Arduino/Trademarks & Licensing/Trademark-guide-for-websites-and-publications.md
+++ b/content/About Arduino/Trademarks & Licensing/Trademark-guide-for-websites-and-publications.md
@@ -1,5 +1,6 @@
 ---
 title: "Trademark guide for websites and publications"
+id: 13369309872028
 ---
 
 This guide covers the basic trademark rules for publications about Arduino (examples include but are not limited to: books, articles, dissertations, websites, and blogs). By following these guidelines, you will be able to develop, share, and even commercialize your content without violating Arduino’s Intellectual Property.

--- a/content/Arduino Cloud/Arduino IoT Cloud/How-to-delete-Things-in-Arduino-Cloud.md
+++ b/content/Arduino Cloud/Arduino IoT Cloud/How-to-delete-Things-in-Arduino-Cloud.md
@@ -1,5 +1,6 @@
 ---
 title: "How to delete Things in Arduino Cloud"
+id: 360003242899
 ---
 
 Learn how to delete Things in Arduino Cloud.

--- a/content/Arduino Cloud/Arduino IoT Cloud/How-to-delete-Things-in-Arduino-Cloud.md
+++ b/content/Arduino Cloud/Arduino IoT Cloud/How-to-delete-Things-in-Arduino-Cloud.md
@@ -1,6 +1,6 @@
 ---
 title: "How to delete Things in Arduino Cloud"
-id: 360003242899
+id: 13369510226204
 ---
 
 Learn how to delete Things in Arduino Cloud.


### PR DESCRIPTION
The [deploy](https://github.com/arduino/help-center-content/actions/workflows/deploy-prod.yml) action has failed for some of the recently merged pull requests. The action fails at a point where the articles have already been published, but before the resulting article IDs can be committed to the Markdown front matter. As a result, some newly published articles didn't get their article ID inserted in the front matter. This pull request adds the correct article ID for these articles.