### PR TITLE
Patch: Wrap title with quotes

### DIFF
--- a/content/Hardware Support/Portenta Family/FAQ-Arduino-Opta.md
+++ b/content/Hardware Support/Portenta Family/FAQ-Arduino-Opta.md
@@ -1,5 +1,5 @@
 ---
-title: FAQ: Arduino Opta
+title: "FAQ: Arduino Opta"
 id: 13870453088924
 ---
 


### PR DESCRIPTION
Commits like https://github.com/arduino/help-center-content/commit/b944eb0adca5f7cc4d7fa6fa9917cb8445ad0985 are made automatically for new articles, to add article id for the created article to the markdown source. In this case, the title (FAQ: Arduino Opta) included a colon (`:`). Because the action didn't wrap the title in quotes, this is breaking the YAML syntax of the front matter. This PR fixes this specific instance by wrapping the title in quotes.