### PR TITLE
Update documents for the new Agent 1.5.0 "HTTPS Certificate" changes

### DIFF
--- a/content/Arduino Cloud/Cloud Editor/If-the-Arduino-Create-Agent-isnt-detected.md
+++ b/content/Arduino Cloud/Cloud Editor/If-the-Arduino-Create-Agent-isnt-detected.md
@@ -20,7 +20,7 @@ If you haven't done so, [install the Arduino Create Agent](https://create.arduin
 
 2. If you are using [Brave Browser](https://brave.com/), see [Use Arduino Cloud with Brave Browser](https://support.arduino.cc/hc/en-us/articles/10482021304988-Use-Arduino-Cloud-with-Brave-Browser).
 
-3. Check if the HTTPS certificate for macOS Safari has been installed:
+3. **If you're using Safari on macOS:** Check if the HTTPS certificate for Safari has been installed:
     1. Open the Arduino Create Agent menu (Look for the ![Arduino Create Agent icon](img/create-agent-logo-mac.png) icon in the top-right of the menu bar of macOS).
     2. Click on the **Manage HTTPS certificate** menu and make sure that the certificate is installed and trusted.  
        If it’s not, you can click on the button "Install the certificate for Safari".

--- a/content/Arduino Cloud/Cloud Editor/If-the-Arduino-Create-Agent-isnt-detected.md
+++ b/content/Arduino Cloud/Cloud Editor/If-the-Arduino-Create-Agent-isnt-detected.md
@@ -20,13 +20,12 @@ If you haven't done so, [install the Arduino Create Agent](https://create.arduin
 
 2. If you are using [Brave Browser](https://brave.com/), see [Use Arduino Cloud with Brave Browser](https://support.arduino.cc/hc/en-us/articles/10482021304988-Use-Arduino-Cloud-with-Brave-Browser).
 
-3. Make sure that the HTTPS Certificates are installed:
-    <ol type="I">
-      <li>Open the Arduino Create Agent menu (Look for the <img src="img/create-agent-logo-mac.png" alt="Arduino Create Agent icon"> icon in the top-right of the menu bar for macOS and Linux or in the bottom-right of the taskbar within the system tray, for Windows).</li>
-      <li>If the <b>Generate and Install HTTPS Certificates</b>option is available, click it. If it's disabled, the certificates are already installed.</li>
-      <li>Enter the password if prompted.</li>
-      <li>Refresh the browser window.</li>
-    </ol>
+3. Check if the HTTPS certificate for macOS Safari has been installed:
+    1. Open the Arduino Create Agent menu (Look for the ![Arduino Create Agent icon](img/create-agent-logo-mac.png) icon in the top-right of the menu bar of macOS).
+    2. Click on the **Manage HTTPS certificate** menu and make sure that the certificate is installed and trusted.  
+       If it’s not, you can click on the button "Install the certificate for Safari".
+    3. Enter the administrative credentials, if prompted.
+    4. Refresh the Safari browser window.
 
 4. If you're using the [Create Agent on a Mac computer with an Apple Silicon processor](https://github.com/arduino/arduino-create-agent#apple-m1-support) (e.g. Apple M1 chip), make sure to [install Rosetta 2](https://support.apple.com/en-us/HT211861).
 

--- a/content/Arduino Cloud/Cloud Editor/If-your-board-is-not-detected-by-Arduino-Cloud-Editor.md
+++ b/content/Arduino Cloud/Cloud Editor/If-your-board-is-not-detected-by-Arduino-Cloud-Editor.md
@@ -24,11 +24,12 @@ Learn how to troubleshoot possible issues when connecting a board to the Cloud E
 3. Ensure you've connected your board with a working data USB cable.
 4. If you haven't done so already, [install Arduino Create Agent](https://create.arduino.cc/getting-started/plugin/welcome).
 5. [Check if the Arduino Create Agent is installed and running](https://support.arduino.cc/hc/en-us/articles/4980687506844-Check-if-the-Arduino-Create-Agent-is-installed-and-running).
-6. Check if HTTPS certificates have been installed:
-    1. Open the Arduino Create Agent menu (Look for the ![Arduino Create Agent icon](img/create-agent-logo-mac.png) icon in the top-right of the menu bar for macOS and Linux or in the bottom-right of the taskbar within the system tray, for Windows).
-    2. If the **Generate and Install HTTPS Certificates** option is available, click it. If it's disabled, the certificates are already installed.
-    3. Enter password if prompted.
-    4. Refresh the browser window.
+6. Check if the HTTPS certificate for macOS Safari has been installed:
+    1. Open the Arduino Create Agent menu (Look for the ![Arduino Create Agent icon](img/create-agent-logo-mac.png) icon in the top-right of the menu bar of macOS).
+    2. Click on the **Manage HTTPS certificate** menu and make sure that the certificate is installed and trusted.  
+       If it’s not, you can click on the button "Install the certificate for Safari".
+    4. Enter the administrative credentials, if prompted.
+    5. Refresh the Safari browser window.
 
 ### Classic Nano boards and boards with generic USB chips
 

--- a/content/Arduino Cloud/Cloud Editor/If-your-board-is-not-detected-by-Arduino-Cloud-Editor.md
+++ b/content/Arduino Cloud/Cloud Editor/If-your-board-is-not-detected-by-Arduino-Cloud-Editor.md
@@ -24,7 +24,7 @@ Learn how to troubleshoot possible issues when connecting a board to the Cloud E
 3. Ensure you've connected your board with a working data USB cable.
 4. If you haven't done so already, [install Arduino Create Agent](https://create.arduino.cc/getting-started/plugin/welcome).
 5. [Check if the Arduino Create Agent is installed and running](https://support.arduino.cc/hc/en-us/articles/4980687506844-Check-if-the-Arduino-Create-Agent-is-installed-and-running).
-6. Check if the HTTPS certificate for macOS Safari has been installed:
+6. **If you're using Safari on macOS:** Check if the HTTPS certificate for Safari has been installed:
     1. Open the Arduino Create Agent menu (Look for the ![Arduino Create Agent icon](img/create-agent-logo-mac.png) icon in the top-right of the menu bar of macOS).
     2. Click on the **Manage HTTPS certificate** menu and make sure that the certificate is installed and trusted.  
        If it’s not, you can click on the button "Install the certificate for Safari".

--- a/content/Arduino Cloud/Cloud Editor/If-your-board-is-not-detected-by-Arduino-Cloud-Editor.md
+++ b/content/Arduino Cloud/Cloud Editor/If-your-board-is-not-detected-by-Arduino-Cloud-Editor.md
@@ -28,8 +28,8 @@ Learn how to troubleshoot possible issues when connecting a board to the Cloud E
     1. Open the Arduino Create Agent menu (Look for the ![Arduino Create Agent icon](img/create-agent-logo-mac.png) icon in the top-right of the menu bar of macOS).
     2. Click on the **Manage HTTPS certificate** menu and make sure that the certificate is installed and trusted.  
        If it’s not, you can click on the button "Install the certificate for Safari".
-    4. Enter the administrative credentials, if prompted.
-    5. Refresh the Safari browser window.
+    3. Enter the administrative credentials, if prompted.
+    4. Refresh the Safari browser window.
 
 ### Classic Nano boards and boards with generic USB chips
 


### PR DESCRIPTION
- Updated the document so that the troubleshooting steps are correct for the new 1.5.0 version of the Arduino Agent.
- Renamed Certificates to Certificate, as there is only one.
- Removed the part about the icon menu for Linux and Windows, as the HTTPS certificate is not used or needed there.

Updated documents:
- content/Arduino Cloud/Cloud Editor/If-your-board-is-not-detected-by-Arduino-Cloud-Editor.md
- content/Arduino Cloud/Cloud Editor/If-the-Arduino-Create-Agent-isnt-detected.md