### PR TITLE
Correct erroneous information re: sketchbook path

### DIFF
--- a/content/Software Support/IDE Settings/Use-a-custom-theme-for-Arduino-IDE-1.md
+++ b/content/Software Support/IDE Settings/Use-a-custom-theme-for-Arduino-IDE-1.md
@@ -12,7 +12,7 @@ Learn how to install a .zip packaged theme for Arduino IDE 1.
 1. Open the Sketchbook folder. By default it is located in:
    * Windows: `C:\Users\{username}\Documents\Arduino`
    * macOS: `~/Documents/Arduino`
-   * Linux: `~/sketchbook`
+   * Linux: `~/Arduino`
 
    You can check the location in Preferences, under _Sketchbook location_:
 

--- a/content/Software Support/Installation/How-to-install-and-use-a-custom-core-version-in-the-IDE.md
+++ b/content/Software Support/Installation/How-to-install-and-use-a-custom-core-version-in-the-IDE.md
@@ -38,11 +38,11 @@ The core can be downloaded with a web browser or by cloning the git repo.
 ### Using your web browser
 
 1. Download the git repo. In GitHub this is done by clicking `Code > Download ZIP`.
-2. Extract the core into `<sketchbook>/Arduino/hardware/<vendor>/<architecture>`.
+2. Extract the core into `<sketchbook>/hardware/<vendor>/<architecture>`.
 
 ### Using git
 
-Simply navigate into `Arduino/hardware/<vendor>` and clone the repo into a folder named `<architecture>`.
+Simply navigate into `<sketchbook>/hardware/<vendor>` and clone the repo into a folder named `<architecture>`.
 
 ```
 cd <sketchbook>/hardware/<vendor>


### PR DESCRIPTION
The "How to install and use a custom core version in the IDE" Help Center article provides instructions for manual installation of Arduino boards platforms under the sketchbook folder. Since the sketchbook folder path may differ depending on operating system and configuration of Arduino IDE, the placeholder `<sketchbook>` is used to refer to the path of the sketchbook folder in the article.

Previously some of the instructions in the article incorrectly included a folder named `Arduino` under the sketchbook path.

---

I did a comprehensive review of the content to check for similar errors in other articles. I also found that the information about the default sketchbook path on Linux was incorrect and have fixed that as well.

---

Originally reported at https://forum.arduino.cc/t/manually-installing-the-arduinocore-megaavr-board-package-into-ide/1265911