### PR TITLE
Correct data directory paths

### DIFF
--- a/content/Hardware Support/UNO/Debug-runtime-errors-on-UNO-R4-WiFi-using-stack-trace.md
+++ b/content/Hardware Support/UNO/Debug-runtime-errors-on-UNO-R4-WiFi-using-stack-trace.md
@@ -71,7 +71,7 @@ Install `addr2line` (optional):
 * **Linux:**
   1. Copy the command from the serial output.
   2. Paste the command into a text editor.
-  3. Replace the word `addr2line` with `.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/bin/arm-none-eabi-addr2line`.
+  3. Replace the word `addr2line` with `~/.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/bin/arm-none-eabi-addr2line`.
 
 ### 2. Running the addr2line command
 

--- a/content/Software Support/IDE Settings/Find-sketches-libraries-board-cores-and-other-files-on-your-computer.md
+++ b/content/Software Support/IDE Settings/Find-sketches-libraries-board-cores-and-other-files-on-your-computer.md
@@ -90,7 +90,7 @@ Board platforms installed with the Board Manager are stored inside the Arduino15
 1. Open the Arduino15 folder.
    * **Windows:** `C:\Users\{username}\AppData\Local\Arduino15`
    * **macOS:** `/Users/{username}/Library/Arduino15`
-   * **Linux:** `home/{username}/.arduino15`
+   * **Linux:** `/home/{username}/.arduino15`
 
    > For detailed instructions, see [Open the Arduino15 folder](https://support.arduino.cc/hc/en-us/articles/360018448279-Open-the-Arduino15-folder).
 

--- a/content/Software Support/IDE Settings/Modify-the-buffer-size-of-the-Wire-library.md
+++ b/content/Software Support/IDE Settings/Modify-the-buffer-size-of-the-Wire-library.md
@@ -13,8 +13,8 @@ To locate the `Wire.h` library in the Arduino installation path and modify its b
 
    * **Windows (IDE 2):** `C:\Users\{username}\AppData\Local\Arduino15\packages\arduino\hardware\avr\{version}\libraries\Wire\src\Wire.h`
    * **Windows (IDE 1.x):** `C:\Program Files (x86)\Arduino\hardware\arduino\avr\libraries\Wire\src\Wire.h`
-   * **macOS:** `~/Library/Arduino15/hardware/arduino/avr/libraries/Wire/src/Wire.h`
-   * **Linux:** `~/sketchbook/hardware/arduino/avr/libraries/Wire/src/Wire.h`
+   * **macOS:** `~/Library/Arduino15/packages/arduino/hardware/avr/{version}/libraries/Wire/src/Wire.h`
+   * **Linux:** `~/.arduino15/packages/arduino/hardware/avr/{version}/libraries/Wire/src/Wire.h`
 
 3. Open the file `Wire.h` with a text editor.
 

--- a/content/Software Support/IDE Settings/Open-the-Arduino15-folder.md
+++ b/content/Software Support/IDE Settings/Open-the-Arduino15-folder.md
@@ -51,12 +51,12 @@ Full path: `/Users/{username}/Library/Arduino15`
 
 ## Linux
 
-The folder is located in `home/{username}/.arduino15` and is hidden by default. To show it, click the hamburger button and check _Show Hidden Files_. You may have to scroll down to see it since files with the `.` prefix may be listed after the others.
+The folder is located in `/home/{username}/.arduino15` and is hidden by default. To show it, click the hamburger button and check _Show Hidden Files_. You may have to scroll down to see it since files with the `.` prefix may be listed after the others.
 
 ![Enabling hidden files in the Files application on Ubuntu.](img/ubuntu-files-hidden.png)
 
 > [!NOTE]
-> By default the folder is hidden; therefore, if you're unable to locate the Arduino15 folder please refer to the bottom of the page.
+> By default the folder is hidden; therefore, if you're unable to locate the .arduino15 folder please refer to the bottom of the page.
 
 ---
 

--- a/content/Software Support/Installation/Uninstall-Arduino-IDE.md
+++ b/content/Software Support/Installation/Uninstall-Arduino-IDE.md
@@ -58,7 +58,7 @@ Default location:
 * **Windows:** `C:\Users\{username}\AppData\Local\Arduino15`. Open your Users folder in Explorer and look for a folder called `AppData`.
   * This folder is hidden by default. In newer versions of Windows, you can display hidden items by clicking the **View** tab, and checking _Hidden items_.
 * **macOS:** `/Users/{username}/Library/Arduino15`. Open Finder and navigate to the home folder `(/Users/{username})`. From the Finder menu bar, click on `View > Show View Options`, and tick _Show Library Folder_. The `Arduino15` folder can now be found in `{username}/Library`.
-* **Linux:** The folder is located in `home/{username}/.arduino15` and is hidden by default. To show it, click the hamburger button and check Show Hidden Files.
+* **Linux:** The folder is located in `/home/{username}/.arduino15` and is hidden by default. To show it, click the hamburger button and check Show Hidden Files.
 
 ### Configuration folder (.arduinoIDE)
 


### PR DESCRIPTION
Arduino development tools store files such as boards packages in a folder referred to as the "[data directory](https://arduino.github.io/arduino-cli/dev/configuration/#:~:text=by%20Arduino%20CLI.-,data,-%2D%20directory%20used%20to)". The path of this folder is referenced in various Help Center articles.

Some of the references to the path of the "data directory" or its subfolders were incorrect.