### PR TITLE
Directly link to the cloud editor

### DIFF
--- a/content/Arduino Cloud/Cloud Editor/Open-the-Cloud-Editor.md
+++ b/content/Arduino Cloud/Cloud Editor/Open-the-Cloud-Editor.md
@@ -5,7 +5,7 @@ id: 13809101080732
 
 To open a sketch in the Cloud Editor, follow these steps:
 
-1. Go to [app.arduino.cc/sketches](app.arduino.cc/sketches).
+1. Go to [app.arduino.cc/sketches](https://app.arduino.cc/sketches).
 
 1. Choose a sketch to open in the Cloud Editor:
 


### PR DESCRIPTION
Minor fix to navigate to the correct page instead of navigating to a non-existent sub-directory.
@ https://support.arduino.cc/hc/en-us/articles/13809101080732-Open-the-Cloud-Editor
![image](https://github.com/user-attachments/assets/e40ca094-fcea-481d-9cec-e133408fe40e)

I did a search in the repo, and I didn't see any other occurences of this mistake (at least with `app.arduino.cc`)