### PR TITLE
Add quotes to title

### DIFF
--- a/content/Hardware Support/Portenta Family/FAQ-Arduino-Portenta-X8.md
+++ b/content/Hardware Support/Portenta Family/FAQ-Arduino-Portenta-X8.md
@@ -1,5 +1,5 @@
 ---
-title: FAQ: Arduino Portenta X8
+title: "FAQ: Arduino Portenta X8"
 id: 15579050846364
 ---
 


### PR DESCRIPTION
Fixes
```
YAMLException: incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line at line 1, column 11:
    title: FAQ: Arduino Portenta X8
```