### PR TITLE
Update Can-I-use-processing-in-Chromebooks.md to mention Processing compatibility with Linux on ChromeOS

### DIFF
--- a/content/Education and Kits/CTC 101 and CTC UNO/Can-I-use-processing-in-Chromebooks.md
+++ b/content/Education and Kits/CTC 101 and CTC UNO/Can-I-use-processing-in-Chromebooks.md
@@ -3,4 +3,10 @@ title: "Can I use processing in Chromebooks?"
 id: 360017098519
 ---
 
-It is not possible to install processing in Chromebooks, but the projects can be programmed online. See [Use Processing in your browser](https://support.arduino.cc/hc/en-us/articles/360017098499).
+Yes, you can use Processing on Chromebooks that support Linux on ChromeOS. Most Chromebooks released after 2019, and some earlier models, allow this. Follow this [video tutorial](https://www.youtube.com/watch?v=OteeRNblwxU) for instructions on how to install Processing on your Chromebook.
+
+To check if your Chromebook supports Linux, visit [ChromeOS Systems Supporting Linux](https://www.chromium.org/chromium-os/chrome-os-systems-supporting-linux/).
+
+If you're using a Chromebook from a school or workplace, Linux may be disabled. In that case, ask [your administrator](https://support.google.com/accounts/answer/6208960?sjid=7209928928643098082-EU) for help.
+
+If you can’t install Processing, you can still code Processing or p5.js projects online. See [Use Processing in your browser](https://support.arduino.cc/hc/en-us/articles/360017098499).


### PR DESCRIPTION
Clarified that Processing can be installed on Chromebooks via Linux on ChromeOS and added useful references and context.