### PR TITLE
[HC-1076] patch: linter ignores multiple consecutive blank lines after front matter

### DIFF
--- a/scripts/linter/markdownlint.yml
+++ b/scripts/linter/markdownlint.yml
@@ -31,6 +31,7 @@ HC005:
 HC006:
   title_line_length: 124
 HC008: true
+HC009: true
 MD045: true
 
 # Added 2026-03-09

--- a/scripts/linter/markdownlint/Rules.md
+++ b/scripts/linter/markdownlint/Rules.md
@@ -153,3 +153,17 @@ Starting with the article title, the filename is determined by following these s
 4. Append the `.md` extension
 
 Resolve the error by renaming the file to the expected filename.
+
+<a name="hc009"></a>
+
+## HC009 - Front matter blank lines
+
+Tags: front-matter, blank_lines
+
+Aliases: front-matter-repeated-blank-lines
+
+This rule is triggered when there is not exactly one empty line immediately following the front matter.
+
+Exactly one blank line is required immediately after the front matter.
+
+Rationale: Extraneous or missing blank lines after the front matter clutter the document structure or reduce readability. This rule is specifically needed because the standard MD012 rule does not catch empty lines immediately following front matter.

--- a/scripts/linter/markdownlint/rules/hc009.js
+++ b/scripts/linter/markdownlint/rules/hc009.js
@@ -1,0 +1,31 @@
+// @ts-check
+
+"use strict";
+
+const { addError } = require("markdownlint/helpers");
+
+module.exports = {
+  "names": [ "HC009", "front-matter-repeated-blank-lines" ],
+  "description": "Exactly one blank line after front matter",
+  "tags": [ "front-matter", "blank_lines" ],
+  "function": function HC009(params, onError) {
+    const fmLines = params.frontMatterLines;
+    if (fmLines.length > 0) {
+      // Find the closing delimiter index by looking for the last non-blank element
+      let closingIndex = fmLines.length - 1;
+      while (closingIndex >= 0 && fmLines[closingIndex].trim() === "") {
+        closingIndex--;
+      }
+
+      const blankLinesCount = fmLines.length - 1 - closingIndex;
+      if (blankLinesCount !== 1) {
+        addError(
+          onError,
+          1,
+          `Expected exactly one blank line after front matter, but found ${blankLinesCount}.`,
+          null
+        );
+      }
+    }
+  }
+};

--- a/scripts/linter/markdownlint/rules/rules.js
+++ b/scripts/linter/markdownlint/rules/rules.js
@@ -13,7 +13,8 @@ const rules = [
   require("./hc005"),
   require("./hc006"),
   require("./hc007"),
-  require("./hc008")
+  require("./hc008"),
+  require("./hc009")
 ];
 
 rules.forEach((rule) => {

--- a/scripts/linter/package.json
+++ b/scripts/linter/package.json
@@ -4,7 +4,7 @@
   "description": "Linter for the Arduino Help Center repository",
   "main": "markdownlint.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test-hc009.js",
     "lint": "node markdownlint.js"
   },
   "repository": {

--- a/scripts/linter/test-hc009.js
+++ b/scripts/linter/test-hc009.js
@@ -1,0 +1,98 @@
+// @ts-check
+
+'use strict';
+
+const path = require('path');
+const markdownIt = require('markdown-it');
+const rule = require('./markdownlint/rules/hc009');
+
+async function test() {
+  const { lint } = await import('markdownlint/sync');
+
+  const testCases = [
+    {
+      name: "Valid: 1 blank line after front matter",
+      content: `---\ntitle: "Hello"\n---\n\n## Heading 1\n`,
+      expectedErrors: 0
+    },
+    {
+      name: "Invalid: 0 blank lines after front matter",
+      content: `---\ntitle: "Hello"\n---\n## Heading 1\n`,
+      expectedErrors: 1,
+      expectedLineNumbers: [4]
+    },
+    {
+      name: "Invalid: 2 blank lines after front matter",
+      content: `---\ntitle: "Hello"\n---\n\n\n## Heading 1\n`,
+      expectedErrors: 1,
+      expectedLineNumbers: [6]
+    },
+    {
+      name: "Invalid: 3 blank lines after front matter",
+      content: `---\ntitle: "Hello"\n---\n\n\n\n## Heading 1\n`,
+      expectedErrors: 1,
+      expectedLineNumbers: [7]
+    },
+    {
+      name: "Valid: No front matter",
+      content: `## Heading 1\n\nSome text\n`,
+      expectedErrors: 0
+    }
+  ];
+
+  console.log("🧪 Running HC009 unit tests...");
+  let passed = true;
+
+  for (const tc of testCases) {
+    const options = {
+      config: {
+        default: false,
+        HC009: true
+      },
+      strings: {
+        "test.md": tc.content
+      },
+      customRules: [rule],
+      resultVersion: 3,
+      markdownItFactory: () => markdownIt({ "html": true })
+    };
+
+    const result = lint(options);
+    const errors = result["test.md"] || [];
+
+    const actualErrorsCount = errors.length;
+    if (actualErrorsCount !== tc.expectedErrors) {
+      console.error(`❌ Case "${tc.name}" failed: expected ${tc.expectedErrors} error(s), got ${actualErrorsCount}`);
+      console.error("Actual errors:", errors);
+      passed = false;
+    } else {
+      // Check line numbers if expected
+      if (tc.expectedLineNumbers) {
+        const actualLineNumbers = errors.map(e => e.lineNumber).sort((a, b) => a - b);
+        const match = tc.expectedLineNumbers.length === actualLineNumbers.length &&
+          tc.expectedLineNumbers.every((v, i) => v === actualLineNumbers[i]);
+        if (!match) {
+          console.error(`❌ Case "${tc.name}" failed: expected line numbers ${tc.expectedLineNumbers}, got ${actualLineNumbers}`);
+          passed = false;
+        } else {
+          console.log(`✅ Case "${tc.name}" passed!`);
+        }
+      } else {
+        console.log(`✅ Case "${tc.name}" passed!`);
+      }
+    }
+  }
+
+  if (passed) {
+    console.log("🎉 All HC009 unit tests passed successfully!");
+    process.exit(0);
+  } else {
+    console.error("💔 Some unit tests failed.");
+    process.exit(1);
+  }
+}
+
+test().catch(err => {
+  console.error("Error during testing:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
This PR adds a new markdownlint rule that enforces exactly one empty line after the article's front matter.